### PR TITLE
avoid unnecessary closures

### DIFF
--- a/R/format_stat.R
+++ b/R/format_stat.R
@@ -216,9 +216,7 @@ setMethod(
                     ))
         }
         st <- set_excel_data_format(st, "#,##0", row_id = row_id, col_id = col_id)
-        set_latex_pre_process(
-            st,
-            function(x) {
+        latex_pre_proc = function(x) {
                 if (!is.na(x) && x != 0) {
                     format(round(x, 0), nsmall = 0, big.mark = ".", decimal.mark = ",")
                 } else if (!is.na(x) && x == 0) {
@@ -226,7 +224,11 @@ setMethod(
                 } else {
                     "$\\cdot$"
                 }
-            },
+            }
+        environment(latex_pre_proc) <- .GlobalEnv
+        set_latex_pre_process(
+            st,
+            latex_pre_proc,
             row_id = row_id,
             col_id = col_id)
     }
@@ -286,9 +288,7 @@ setMethod(
                     ))
         }
         st <- set_excel_data_format(st, "#,##0.0", row_id = row_id, col_id = col_id)
-        set_latex_pre_process(
-            st,
-            function(x) {
+        latex_pre_proc = function(x) {
                 if (!is.na(x) && x != 0) {
                     format(round(x, 1), nsmall = 1, decimal.mark = ",")
                 } else if (!is.na(x) && x == 0) {
@@ -296,7 +296,11 @@ setMethod(
                 } else {
                     "$\\cdot$"
                 }
-            },
+            }
+        environment(latex_pre_proc) <- .GlobalEnv
+        set_latex_pre_process(
+            st,
+            latex_pre_proc,
             row_id = row_id,
             col_id = col_id)
     }

--- a/R/styled_cell.R
+++ b/R/styled_cell.R
@@ -313,7 +313,7 @@ setMethod("initialize", signature(.Object = "StyledCell"),
         if (!missing(excel_pre_process)) {
             .Object@excel_pre_process <- excel_pre_process
         } else {
-            .Object@excel_pre_process <- function(x) x
+            .Object@excel_pre_process <- base::identity
         }
         if (!missing(latex_pre_process)) {
             .Object@latex_pre_process <- latex_pre_process
@@ -404,7 +404,7 @@ setMethod("getStyledCell", signature(sc = "StyledCell"),
 setMethod("getStyledCell", signature(sc = "MissingOrNull"),
     function(sc, style_name) {
         if (style_name %in% c("excel_pre_process", "latex_pre_process"))
-            return(function(x) x)
+            return(base::identity)
         NULL
     }
 )


### PR DESCRIPTION
for every single StyledCell two closures are created which took up to ~5MB in this case. multiply by a couple thousands and poof! all your ram is gone.